### PR TITLE
Fix deprecation error

### DIFF
--- a/sources/OAuth2/ResponseType/AccessToken.php
+++ b/sources/OAuth2/ResponseType/AccessToken.php
@@ -114,6 +114,12 @@ class AccessToken implements AccessTokenInterface
      */
     protected function generateAccessToken()
     {
+        if (function_exists('random_bytes')) {
+            $randomData = random_bytes(20);
+            if ($randomData !== false && strlen($randomData) === 20) {
+                return bin2hex($randomData);
+            }
+        }
         if (function_exists('mcrypt_create_iv')) {
             $randomData = mcrypt_create_iv(20, MCRYPT_DEV_URANDOM);
             if ($randomData !== false && strlen($randomData) === 20) {
@@ -181,7 +187,7 @@ class AccessToken implements AccessTokenInterface
 
         $revoked = $this->tokenStorage->unsetAccessToken($token);
 
-        // if a typehint is supplied and fails, try other storages 
+        // if a typehint is supplied and fails, try other storages
         // @see https://tools.ietf.org/html/rfc7009#section-2.1
         if (!$revoked && $tokenTypeHint != 'refresh_token') {
             if ($this->refreshStorage) {

--- a/sources/OAuth2/ResponseType/AuthorizationCode.php
+++ b/sources/OAuth2/ResponseType/AuthorizationCode.php
@@ -85,7 +85,9 @@ class AuthorizationCode implements AuthorizationCodeInterface
     protected function generateAuthorizationCode()
     {
         $tokenLen = 40;
-        if (function_exists('mcrypt_create_iv')) {
+        if (function_exists('random_bytes')) {
+            $randomData = random_bytes(100);
+        } elseif (function_exists('mcrypt_create_iv')) {
             $randomData = mcrypt_create_iv(100, MCRYPT_DEV_URANDOM);
         } elseif (function_exists('openssl_random_pseudo_bytes')) {
             $randomData = openssl_random_pseudo_bytes(100);


### PR DESCRIPTION
`mcrypt_create_iv()` is deprecated in PHP 7.1 and removed in PHP 7.2. The latter is less severe because there are fallbacks, but 7.1 crashes with deprecation errors.

This checks for `random_bytes()` first and prefers it over `mcrypt_create_iv()`.